### PR TITLE
fix - check for array key instead of value

### DIFF
--- a/Classes/Common/MetsDocument.php
+++ b/Classes/Common/MetsDocument.php
@@ -1177,9 +1177,9 @@ final class MetsDocument extends AbstractDocument
             $physicalStructureNode = $this->physicalStructureInfo[$id];
             $fileLocations = [];
 
-            if (!empty($physicalStructureNode)) {
+            if (!empty($physicalStructureNode) && array_key_exists('files', $physicalStructureNode)) {
                 while ($useGroup = array_shift($useGroups)) {
-                    if (in_array($useGroup, $physicalStructureNode['files'])) {
+                    if (array_key_exists($useGroup, $physicalStructureNode['files'])) {
                         $fileLocations[$useGroup] = $this->getFileLocation($physicalStructureNode['files'][$useGroup]);
                     }
                 }


### PR DESCRIPTION
I tested your Branch indexing the Document Example:
https://digital.ladenburg.de/data/Ladenburger_Wochenblatt/mets18690415.xml

It was necessary to check if the `files` Array Key exists upfront and check for the `useGroup` Key instead of the Value in `$physicalStructureNode['files']` otherwise it wouldn't match.